### PR TITLE
Make AndroidPermissionCallback directly usable.

### DIFF
--- a/Assets/Scripts/AndroidPermissionsManager.cs
+++ b/Assets/Scripts/AndroidPermissionsManager.cs
@@ -4,15 +4,30 @@ public class AndroidPermissionCallback : AndroidJavaProxy
 {
     public AndroidPermissionCallback() : base("com.unity3d.player.UnityAndroidPermissions$IPermissionRequestResult") { }
 
+    public bool IsCallbackComplete
+    {
+        protected set;
+        get;
+    }
+    public bool IsGranted
+    {
+        protected set;
+        get;
+    }
+
     // Handle permission granted
     public virtual void OnPermissionGranted(string permissionName)
     {
         //Debug.Log("Permission " + permissionName + " GRANTED");
+        IsCallbackComplete = true;
+        IsGranted = true;
     }
 
     // Handle permission denied
     public virtual void OnPermissionDenied(string permissionName)
     {
+        IsCallbackComplete = true;
+        IsGranted = false;
         //Debug.Log("Permission " + permissionName + " DENIED!");
     }
 }


### PR DESCRIPTION
Minor change that allows implementing code to check callback status without overriding AndroidPermissionCallback class.

I understand if you prefer overriding, but I thought it was such a minor change, and it saves users of this code having to make an additional class.

By the way, out of 6 or 7 projects on github attempting to do this. You're the only one whose done it really well. Thanks!!